### PR TITLE
refactored oc-plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.16
 
 require (
 	github.com/spf13/cobra v1.1.3
+	k8s.io/api v0.21.0
+	k8s.io/apimachinery v0.21.0
 	k8s.io/cli-runtime v0.21.0
 	k8s.io/client-go v0.21.0
 	k8s.io/kubectl v0.21.0

--- a/pkg/client/k8s_client.go
+++ b/pkg/client/k8s_client.go
@@ -9,8 +9,9 @@ import (
 )
 
 type KubernetesOptions struct {
-	Clientset  kubernetes.Interface
-	ClusterUrl string
+	Clientset        kubernetes.Interface
+	ClusterUrl       string
+	CurrentNamespace string
 }
 
 func KubernetesClient() (*KubernetesOptions, error) {
@@ -28,6 +29,11 @@ func KubernetesClient() (*KubernetesOptions, error) {
 	if err != nil {
 		return nil, fmt.Errorf("an error occurred while creating kubernetes client: %v", err)
 	}
+
+	clientCfg, _ := clientcmd.NewDefaultClientConfigLoadingRules().Load()
+	namespace := clientCfg.Contexts[clientCfg.CurrentContext].Namespace
+
+	kubernetesOptions.CurrentNamespace = namespace
 	kubernetesOptions.Clientset = clientset
 	kubernetesOptions.ClusterUrl = config.Host
 	return kubernetesOptions, nil

--- a/pkg/client/k8s_client.go
+++ b/pkg/client/k8s_client.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"fmt"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"os"
+	"path/filepath"
+)
+
+type KubernetesOptions struct {
+	Clientset  kubernetes.Interface
+	ClusterUrl string
+}
+
+func KubernetesClient() (*KubernetesOptions, error) {
+
+	kubernetesOptions := &KubernetesOptions{}
+	kubeconfig := filepath.Join(
+		os.Getenv("HOME"), ".kube", "config",
+	)
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("kubeconfig Error: %v", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("an error occurred while creating kubernetes client: %v", err)
+	}
+	kubernetesOptions.Clientset = clientset
+	kubernetesOptions.ClusterUrl = config.Host
+	return kubernetesOptions, nil
+}

--- a/pkg/cmd/historical_logs.go
+++ b/pkg/cmd/historical_logs.go
@@ -173,9 +173,9 @@ func (o *LogParameters) Execute(streams genericclioptions.IOStreams) error {
 		for _, pod := range podList {
 
 			o.Podname = pod
-			response,err := o.makeHttpRequest(ApiUrl)
+			response, err := o.makeHttpRequest(ApiUrl)
 
-			if err!=nil{
+			if err != nil {
 				return err
 			}
 
@@ -197,8 +197,8 @@ func (o *LogParameters) Execute(streams genericclioptions.IOStreams) error {
 
 	} else {
 
-		response,err := o.makeHttpRequest(ApiUrl)
-		if err!=nil{
+		response, err := o.makeHttpRequest(ApiUrl)
+		if err != nil {
 			return err
 		}
 		responseBody, err := ioutil.ReadAll(response.Body)
@@ -219,59 +219,59 @@ func (o *LogParameters) Execute(streams genericclioptions.IOStreams) error {
 	return nil
 }
 
-func (o *LogParameters) makeHttpRequest(baseUrl string) (*http.Response,error) {
+func (o *LogParameters) makeHttpRequest(baseUrl string) (*http.Response, error) {
 
 	var urlBuilder strings.Builder
 	urlBuilder.WriteString(baseUrl)
 	numParameters := 0
-	if len(o.Podname) >0{
+	if len(o.Podname) > 0 {
 		urlBuilder.WriteString("?")
-		urlBuilder.WriteString("podname="+o.Podname)
+		urlBuilder.WriteString("podname=" + o.Podname)
 		numParameters = numParameters + 1
 	}
-	if len(o.Namespace) >0{
-		if numParameters == 0{
+	if len(o.Namespace) > 0 {
+		if numParameters == 0 {
 			urlBuilder.WriteString("?")
-		}else{
+		} else {
 			urlBuilder.WriteString("&")
 		}
-		urlBuilder.WriteString("namespace="+o.Namespace)
+		urlBuilder.WriteString("namespace=" + o.Namespace)
 		numParameters = numParameters + 1
 	}
-	if len(o.Limit) >0{
-		if numParameters == 0{
+	if len(o.Limit) > 0 {
+		if numParameters == 0 {
 			urlBuilder.WriteString("?")
-		}else{
+		} else {
 			urlBuilder.WriteString("&")
 		}
-		urlBuilder.WriteString("maxlogs="+o.Limit)
+		urlBuilder.WriteString("maxlogs=" + o.Limit)
 		numParameters = numParameters + 1
 	}
-	if len(o.Level) >0{
-		if numParameters == 0{
+	if len(o.Level) > 0 {
+		if numParameters == 0 {
 			urlBuilder.WriteString("?")
-		}else{
+		} else {
 			urlBuilder.WriteString("&")
 		}
-		urlBuilder.WriteString("level="+o.Level)
+		urlBuilder.WriteString("level=" + o.Level)
 		numParameters = numParameters + 1
 	}
-	if len(o.StartTime)>0 && len(o.EndTime)>0{
-		if numParameters == 0{
+	if len(o.StartTime) > 0 && len(o.EndTime) > 0 {
+		if numParameters == 0 {
 			urlBuilder.WriteString("?")
-		}else{
+		} else {
 			urlBuilder.WriteString("&")
 		}
-		urlBuilder.WriteString("starttime="+o.StartTime)
-		urlBuilder.WriteString("&finishtime="+o.EndTime)
+		urlBuilder.WriteString("starttime=" + o.StartTime)
+		urlBuilder.WriteString("&finishtime=" + o.EndTime)
 		numParameters = numParameters + 1
 	}
 	response, err := http.Get(urlBuilder.String())
 
 	if err != nil {
-		return nil,fmt.Errorf("http request failed: %v", err)
+		return nil, fmt.Errorf("http request failed: %v", err)
 	}
-	return response,nil
+	return response, nil
 }
 
 func printLogs(logList []string, streams genericclioptions.IOStreams, limit string) error {

--- a/pkg/cmd/historical_logs.go
+++ b/pkg/cmd/historical_logs.go
@@ -24,20 +24,28 @@ import (
 
 var (
 	logsExample = templates.Examples(i18n.T(`
+		
 		# Return snapshot logs from pod openshift-apiserver-operator-849d7869ff-r94g8 with a maximum of 10 Entries
 		oc historical-logs --podname=openshift-apiserver-operator-849d7869ff-r94g8 --limit=10
+		
 		# Return snapshot logs from namespace openshift-apiserver-operator and logging level info
 		oc historical-logs --namespace=openshift-apiserver-operator --level=info
+		
 		# Return snapshot logs from every index without filtering
 		oc historical-logs
+		
 		# Return snapshot of historical-logs from pods of stateful set nginx
 		oc historical-logs --statefulset=nginx
+		
 		# Return snapshot of historical-logs from pods of deployment kibana
 		oc historical-logs --deployment=kibana
+		
 		# Return snapshot of historical-logs from pods of daemon set fluentd
 		oc historical-logs --daemonset=fluentd
+		
 		# Return snapshot logs in a time range between current time - 5 minutes and current time
 		oc historical-logs --tail=5m
+		
 		# Return snapshot logs for pods in deployment log-exploration-api in the last 10 seconds
 		oc historical-logs --deployment=log-exploration-api --tail=10s`))
 )

--- a/pkg/cmd/historical_logs.go
+++ b/pkg/cmd/historical_logs.go
@@ -2,45 +2,58 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"github.com/spf13/cobra"
 	"io/ioutil"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 )
 
 var (
 	logsExample = templates.Examples(i18n.T(`
 		# Return snapshot logs from pod openshift-apiserver-operator-849d7869ff-r94g8 with a maximum of 10 Entries
-		kubectl historical-logs --podname=openshift-apiserver-operator-849d7869ff-r94g8 --maxlogs=10
+		oc historical-logs --podname=openshift-apiserver-operator-849d7869ff-r94g8 --limit=10
 		# Return snapshot logs from namespace openshift-apiserver-operator and logging level info
-		kubectl historical-logs --namespace=openshift-apiserver-operator --level=info
+		oc historical-logs --namespace=openshift-apiserver-operator --level=info
 		# Return snapshot logs from every index without filtering
-		kubectl historical-logs
-		# Return snapshot of historical-logs from Infrastructure index
-		kubectl historical-logs --index=infra-000001
-		# Return snapshot logs in a time range between start and end times
-		kubectl historical-logs --starttime=2021-03-09T03:40:00.163677339Z --finishtime=2021-03-09T03:50:00.163677339Z
-		# Return snapshot logs in a time range between start and end times for the infrastructure index
-		kubectl historical-logs --starttime=2021-03-09T03:40:00.163677339Z --finishtime=2021-03-09T03:50:00.163677339Z --index=infra-000001
-		# Return snapshot a maximum of 20 historical-logs`))
+		oc historical-logs
+		# Return snapshot of historical-logs from pods of stateful set nginx
+		oc historical-logs --statefulset=nginx
+		# Return snapshot of historical-logs from pods of deployment kibana
+		oc historical-logs --deployment=kibana
+		# Return snapshot of historical-logs from pods of daemon set fluentd
+		oc historical-logs --daemonset=fluentd
+		# Return snapshot logs in a time range between current time - 5 minutes and current time
+		oc historical-logs --tail=5m
+		# Return snapshot logs for pods in deployment log-exploration-api in the last 10 seconds
+		oc historical-logs --deployment=log-exploration-api --tail=10s`))
 )
 
 type LogParameters struct {
-	Namespace  string `json:"namespace"`
-	Index      string `json:"index"`
-	Podname    string `json:"podname"`
-	StartTime  string `json:"starttime"`
-	FinishTime string `json:"finishtime"`
-	Level      string `json:"level"`
-	MaxLogs    string `json:"maxlogs"`
+	Namespace   string `json:"namespace"`
+	Podname     string `json:"podname"`
+	Tail        string `json:"tail"`
+	StartTime   string `json:"starttime"`
+	EndTime     string `json:"finishtime"`
+	Level       string `json:"level"`
+	Limit       string `json:"maxlogs"`
+	Deployment  string `json:"deployment"`
+	StatefulSet string `json:"statefulset"`
+	DaemonSet   string `json:"daemonset"`
 }
 
 type ResponseLogs struct {
@@ -69,13 +82,14 @@ func NewCmdLogFilter(streams genericclioptions.IOStreams) *cobra.Command {
 
 func (o *LogParameters) AddFlags(cmd *cobra.Command) {
 
-	cmd.Flags().StringVar(&o.Podname, "podname", "", "Filter Historical logs on a specific pod name.")
+	cmd.Flags().StringVar(&o.Podname, "podname", "", "Filter Historical logs on a specific pod")
 	cmd.Flags().StringVar(&o.Namespace, "namespace", "", "Extract Historical logs from a specific namespace")
-	cmd.Flags().StringVar(&o.StartTime, "starttime", "", "Fetch Historical logs from a particular timestamp")
-	cmd.Flags().StringVar(&o.FinishTime, "finishtime", "", "Fetch Historical logs till a timestamp")
+	cmd.Flags().StringVar(&o.Tail, "tail", "", "Fetch Historical logs for the last N seconds, minutes, hours, or days")
 	cmd.Flags().StringVar(&o.Level, "level", "", "Fetch Historical logs from different logging level, Example: Info,debug,Error,Unknown, etc")
-	cmd.Flags().StringVar(&o.MaxLogs, "maxlogs", "", "Specify number of documents [logs] to be fetched. 1000 by default")
-	cmd.Flags().StringVar(&o.Index, "index", "", "Specify Index to filter by [infra-000001/app-000001/audit-000001")
+	cmd.Flags().StringVar(&o.Limit, "limit", "", "Specify number of documents [logs] to be fetched. 1000 by default")
+	cmd.Flags().StringVar(&o.DaemonSet, "daemonset", "", "Fetch logs from pods of a Daemon Set")
+	cmd.Flags().StringVar(&o.StatefulSet, "statefulset", "", "Fetch logs from pods of a Stateful Set")
+	cmd.Flags().StringVar(&o.Deployment, "deployment", "", "Fetch logs from pods of a Deployment")
 
 }
 
@@ -87,14 +101,12 @@ func (o *LogParameters) Execute(streams genericclioptions.IOStreams) error {
 
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
-		return fmt.Errorf("Kubeconfig Error: %v", err)
+		return fmt.Errorf("kubeconfig Error: %v", err)
 	}
 
-	payload := new(bytes.Buffer)
-	err = json.NewEncoder(payload).Encode(o)
-
+	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		return fmt.Errorf("An Error Occurred while encoding JSON: %v", err)
+		return fmt.Errorf("an error occurred while creating a kubernetes client: %v", err)
 	}
 
 	clusterUrl := config.Host
@@ -107,40 +119,276 @@ func (o *LogParameters) Execute(streams genericclioptions.IOStreams) error {
 
 	ApiUrl := "http://log-exploration-api-route-openshift-logging.apps." + clusterName + "/logs/filter"
 
-	req, err := http.NewRequest("GET", ApiUrl, payload)
+	if len(o.Tail) > 0 {
+		tail, err := strconv.Atoi(o.Tail[0 : len(o.Tail)-1]) //extract numeric value. For example, extract 50 from 50s or 10 from 10m
+		if err != nil {
+			return fmt.Errorf("an invalid \"tail\" value was entered: %v", err)
+		}
 
-	if err != nil {
-		return fmt.Errorf("Request Failed: %v", err)
+		timeUnit := o.Tail[len(o.Tail)-1] //Last character (time unit) is 's'(seconds),'m'(minutes),'h'(hours),'d'(days)
+		endTime := time.Now().UTC()
+		var startTime time.Time
+
+		switch timeUnit {
+		case 's':
+			startTime = endTime.Add(time.Duration(-tail) * time.Second).UTC()
+		case 'm':
+			startTime = endTime.Add(time.Duration(-tail) * time.Minute).UTC()
+		case 'h':
+			startTime = endTime.Add(time.Duration(-tail) * time.Hour).UTC()
+		case 'd':
+			startTime = endTime.Add(time.Duration(-tail) * time.Hour * 24)
+		default:
+			return fmt.Errorf("invalid time unit entered in \"tail\". please enter s, m, h, or d as time unit")
+		}
+
+		o.StartTime = startTime.UTC().Format(time.RFC3339Nano)
+		o.EndTime = endTime.UTC().Format(time.RFC3339Nano)
 	}
 
+	var podList []string
+
+	if len(o.Deployment) > 0 {
+		err = GetDeploymentPodsList(clientset, o.Deployment, o.Namespace, &podList)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(o.DaemonSet) > 0 {
+		err = GetDaemonSetPodsList(clientset, o.DaemonSet, o.Namespace, &podList)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(o.StatefulSet) > 0 {
+		err = GetStatefulSetPodsList(clientset, o.StatefulSet, o.Namespace, &podList)
+		if err != nil {
+			return err
+		}
+	}
+
+	var logList []string
 	client := &http.Client{}
-	res, err := client.Do(req)
-	if err != nil {
-		return fmt.Errorf("Response Error: %v", err)
+	if len(podList) > 0 {
+		for _, pod := range podList {
+			o.Podname = pod
+
+			payload := new(bytes.Buffer)
+			err = json.NewEncoder(payload).Encode(o)
+
+			req, err := http.NewRequest("GET", ApiUrl, payload)
+			if err != nil {
+				return fmt.Errorf("http request failed: %v", err)
+			}
+			res, err := client.Do(req)
+			if err != nil {
+				return fmt.Errorf("response error: %v", err)
+			}
+			responseBody, err := ioutil.ReadAll(res.Body)
+			if err != nil {
+				return fmt.Errorf("failed to read response: %v", err)
+			}
+
+			err = getLogs(responseBody, &logList)
+			if err != nil {
+				return err
+			}
+		}
+
+		err = printLogs(logList, streams, o.Limit)
+		if err != nil {
+			return err
+		}
+
+	} else {
+
+		payload := new(bytes.Buffer)
+		err = json.NewEncoder(payload).Encode(o)
+
+		req, err := http.NewRequest("GET", ApiUrl, payload)
+		if err != nil {
+			return fmt.Errorf("http request failed: %v", err)
+		}
+
+		res, err := client.Do(req)
+		if err != nil {
+			return fmt.Errorf("response error: %v", err)
+		}
+		responseBody, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read response: %v", err)
+		}
+
+		err = getLogs(responseBody, &logList)
+		if err != nil {
+			return err
+		}
+
+		err = printLogs(logList, streams, o.Limit)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+func printLogs(logList []string, streams genericclioptions.IOStreams, limit string) error {
+
+	if len(logList) == 0 {
+		_, err := fmt.Fprintf(streams.Out, "No Logs Present, or logs from invalid resources were requested")
+		if err != nil {
+			return fmt.Errorf("an error occurred while printing logs: %v", err)
+		}
+		return nil
 	}
 
-	responseBody, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return fmt.Errorf("Failed to read Response: %v", err)
+	var maxLogs int
+	var err error
+
+	if len(limit) > 0 {
+		maxLogs, err = strconv.Atoi(limit)
+		if err != nil {
+			return fmt.Errorf("incorrect \"limit\" value entered")
+		}
 	}
+
+	for logCount, log := range logList {
+
+		if len(limit) > 0 && logCount > maxLogs {
+			return nil
+		}
+		_, err := fmt.Fprintf(streams.Out, log+"\n")
+		if err != nil {
+			return fmt.Errorf("an error occurred while printing logs: %v", err)
+		}
+	}
+	return nil
+}
+
+func getLogs(responseBody []byte, logList *[]string) error {
 
 	jsonResponse := &ResponseLogs{}
-	json.Unmarshal(responseBody, &jsonResponse)
+	err := json.Unmarshal(responseBody, &jsonResponse)
+	if err != nil {
+		return fmt.Errorf("an error occurred while unmarshalling JSON response: %v", err)
+	}
 
-	for i := 0; i < len(jsonResponse.Logs); i++ {
+	for _, log := range jsonResponse.Logs {
 
-		log := LogOptions{}
-		err = json.Unmarshal([]byte(jsonResponse.Logs[i]), &log)
+		logOption := LogOptions{}
+		err := json.Unmarshal([]byte(log), &logOption)
 
 		if err != nil {
-			return fmt.Errorf("An Error Occurred while decoding response: %v", err)
+			return nil //no logs present
 		}
 
-		if len(log.Source.Message) > 0 {
-			fmt.Fprintf(streams.Out, log.Source.Message+"\n")
+		if len(logOption.Source.Message) > 0 {
+			*logList = append(*logList, logOption.Source.Message)
 		}
+	}
+
+	return nil
+}
+
+func GetDaemonSetPodsList(clientset *kubernetes.Clientset, targetDaemonSet string, namespace string, podList *[]string) error {
+
+	var requiredDaemonSet appsv1.DaemonSet
+	daemonsets, _ := clientset.AppsV1().DaemonSets(namespace).List(context.Background(), metav1.ListOptions{})
+
+	requiredDaemonSetFound := false
+	for _, daemonset := range daemonsets.Items {
+		if daemonset.ObjectMeta.Name == targetDaemonSet {
+			requiredDaemonSetFound = true
+			requiredDaemonSet = daemonset
+			break
+		}
+	}
+
+	if !requiredDaemonSetFound {
+		return fmt.Errorf("daemon set \"%v\" not found", targetDaemonSet)
+	}
+	labelSelector := labels.Set(requiredDaemonSet.Spec.Selector.MatchLabels)
+
+	options := metav1.ListOptions{
+		LabelSelector: string(labelSelector.AsSelector().String()),
+	}
+
+	pods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), options)
+
+	if err != nil {
+		return fmt.Errorf("an error occurred while fetching daemon set pods: %v", err)
+	}
+	for _, pod := range (*pods).Items {
+		*podList = append(*podList, pod.Name)
+	}
+	return nil
+}
+
+func GetStatefulSetPodsList(clientset *kubernetes.Clientset, targetStatefulSet string, namespace string, podList *[]string) error {
+
+	var requiredStatefulSet appsv1.StatefulSet
+	requiredStatefulSetFound := false
+	statefulSets, _ := clientset.AppsV1().StatefulSets(namespace).List(context.Background(), metav1.ListOptions{})
+
+	for _, statefulSet := range statefulSets.Items {
+		fmt.Println(statefulSet.ObjectMeta.Name)
+		if statefulSet.ObjectMeta.Name == targetStatefulSet {
+			requiredStatefulSetFound = true
+			requiredStatefulSet = statefulSet
+			break
+		}
+	}
+	if !requiredStatefulSetFound {
+		return fmt.Errorf("stateful set \"%v\" not found", targetStatefulSet)
 
 	}
 
+	labelSelector := labels.Set(requiredStatefulSet.Spec.Selector.MatchLabels)
+
+	options := metav1.ListOptions{
+		LabelSelector: string(labelSelector.AsSelector().String()),
+	}
+	pods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), options)
+	if err != nil {
+		return fmt.Errorf("an error occurred while fetching stateful set pods: %v", err)
+	}
+	for _, pod := range (*pods).Items {
+		*podList = append(*podList, pod.Name)
+	}
+	return nil
+
+}
+
+func GetDeploymentPodsList(clientset *kubernetes.Clientset, targetDeployment string, namespace string, podList *[]string) error {
+
+	var requiredDeployment appsv1.Deployment
+	deployments, _ := clientset.AppsV1().Deployments(namespace).List(context.Background(), metav1.ListOptions{})
+	requiredDeploymentFound := false
+
+	for _, deployment := range deployments.Items {
+		if deployment.ObjectMeta.Name == targetDeployment {
+			requiredDeploymentFound = true
+			requiredDeployment = deployment
+			break
+		}
+	}
+
+	if !requiredDeploymentFound {
+		return fmt.Errorf("deployment \"%v\" not found", targetDeployment)
+	}
+
+	labelSelector := labels.Set(requiredDeployment.Spec.Selector.MatchLabels)
+
+	options := metav1.ListOptions{
+		LabelSelector: string(labelSelector.AsSelector().String()),
+	}
+	pods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), options)
+	if err != nil {
+		return fmt.Errorf("an error occurred while fetching deployment pods: %v", err)
+	}
+	for _, pod := range (*pods).Items {
+		*podList = append(*podList, pod.Name)
+	}
 	return nil
 }

--- a/pkg/cmd/historical_logs.go
+++ b/pkg/cmd/historical_logs.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/ViaQ/log-exploration-oc-plugin/pkg/client"
+	"github.com/ViaQ/log-exploration-oc-plugin/pkg/constants"
 	"github.com/ViaQ/log-exploration-oc-plugin/pkg/k8sresources"
 	"github.com/ViaQ/log-exploration-oc-plugin/pkg/logs"
 	"github.com/spf13/cobra"
@@ -18,33 +19,26 @@ import (
 
 var (
 	logsExample = templates.Examples(i18n.T(`
+		# Return snapshot historical-logs from pod openshift-apiserver-operator-849d7869ff-r94g8 with a maximum of 10 log extries
+		oc historical-logs podname=openshift-apiserver-operator-849d7869ff-r94g8 --limit=10
 		
-		# Return snapshot logs from pod openshift-apiserver-operator-849d7869ff-r94g8 with a maximum of 10 Entries
-		oc historical-logs --podname=openshift-apiserver-operator-849d7869ff-r94g8 --limit=10
+		# Return snapshot of historical-logs from pods of stateful set prometheus from namespace openshift-apiserver-operator and logging level info
+		oc historical-logs statefulset=prometheus --namespace=openshift-apiserver-operator --level=info
 		
-		# Return snapshot logs from namespace openshift-apiserver-operator and logging level info
-		oc historical-logs --namespace=openshift-apiserver-operator --level=info
+		# Return snapshot of historical-logs from pods of stateful set nginx in the current namespace with pod name and container name as log prefix
+		oc historical-logs statefulset=nginx --prefix=true
 		
-		# Return snapshot logs from every index without filtering
-		oc historical-logs
+		# Return snapshot of historical-logs from pods of deployment kibana in the namespace openshift-logging with a maximum of 100 log entries
+		oc historical-logs deployment=kibana --namespace=openshift-logging --limit=100
 		
-		# Return snapshot of historical-logs from pods of stateful set nginx
-		oc historical-logs --statefulset=nginx
+		# Return snapshot of historical-logs from pods of daemon set fluentd in the current namespace
+		oc historical-logs daemonset=fluentd
 		
-		# Return snapshot of historical-logs from pods of deployment kibana
-		oc historical-logs --deployment=kibana
-		
-		# Return snapshot of historical-logs from pods of daemon set fluentd
-		oc historical-logs --daemonset=fluentd
-		
-		# Return snapshot logs in a time range between current time - 5 minutes and current time
-		oc historical-logs --tail=5m
+		# Return snapshot logs of pods in deployment cluster-logging-operator in a time range between current time - 5 minutes and current time
+		oc historical-logs deployment=cluster-logging-operator --tail=5m
 		
 		# Return snapshot logs for pods in deployment log-exploration-api in the last 10 seconds
-		oc historical-logs --deployment=log-exploration-api --tail=10s
-
-		# Return snapshot logs for pods in deployment log-exploration-api in namespace openshift-logging
-		oc historical-logs --deployment=log-exploration-api --namespace=openshift-logging`))
+		oc historical-logs deployment=log-exploration-api --tail=10s`))
 )
 
 type ResponseLogs struct {
@@ -53,12 +47,11 @@ type ResponseLogs struct {
 
 type LogParameters struct {
 	Namespace string
-	Podname   string
 	Tail      string
 	StartTime string
 	EndTime   string
 	Level     string
-	Limit     string
+	Limit     int
 	Prefix    bool
 	k8sresources.Resources
 }
@@ -68,11 +61,11 @@ func NewCmdLogFilter(streams genericclioptions.IOStreams) *cobra.Command {
 	o := &LogParameters{}
 
 	cmd := &cobra.Command{
-		Use:     "historical-logs [flags]",
+		Use:     "historical-logs [resource-type]=[resource-name] [flags]",
 		Short:   "View logs filtered on various parameters",
 		Example: logsExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := o.Execute(streams)
+			err := o.Execute(streams, args)
 			if err != nil {
 				return err
 			}
@@ -86,25 +79,21 @@ func NewCmdLogFilter(streams genericclioptions.IOStreams) *cobra.Command {
 
 func (o *LogParameters) AddFlags(cmd *cobra.Command) {
 
-	cmd.Flags().StringVar(&o.Podname, "podname", "", "Filter Historical logs on a specific pod")
 	cmd.Flags().StringVar(&o.Namespace, "namespace", "", "Extract Historical logs from a specific namespace")
 	cmd.Flags().StringVar(&o.Tail, "tail", "", "Fetch Historical logs for the last N seconds, minutes, hours, or days")
 	cmd.Flags().StringVar(&o.Level, "level", "", "Fetch Historical logs from different logging level, Example: Info,debug,Error,Unknown, etc")
-	cmd.Flags().StringVar(&o.Limit, "limit", "", "Specify number of documents [logs] to be fetched. 1000 by default")
-	cmd.Flags().StringVar(&o.Resources.DaemonSet, "daemonset", "", "Fetch logs from pods of a Daemon Set")
-	cmd.Flags().StringVar(&o.Resources.StatefulSet, "statefulset", "", "Fetch logs from pods of a Stateful Set")
-	cmd.Flags().StringVar(&o.Resources.Deployment, "deployment", "", "Fetch logs from pods of a Deployment")
+	cmd.Flags().IntVar(&o.Limit, "limit", constants.LimitUpperBound, "Specify number of documents [logs] to be fetched")
 	cmd.Flags().BoolVar(&o.Prefix, "prefix", false, "Prefix each log with the log source (pod name and container name)")
 }
 
-func (o *LogParameters) Execute(streams genericclioptions.IOStreams) error {
+func (o *LogParameters) Execute(streams genericclioptions.IOStreams, args []string) error {
 
 	kubernetesOptions, err := client.KubernetesClient()
 	if err != nil {
 		return err
 	}
 
-	err = o.ProcessLogParameters()
+	err = o.ProcessLogParameters(kubernetesOptions, args)
 
 	if err != nil {
 		return err
@@ -126,126 +115,120 @@ func (o *LogParameters) Execute(streams genericclioptions.IOStreams) error {
 	act as start and end indices. Extract cluster name as substring using start and end Indices i.e, sangupta-tetrh.devcluster.openshift.com to build the log-exploration-api URL*/
 
 	baseUrl := "http://log-exploration-api-route-openshift-logging.apps." + clusterName + "/logs/filter"
-
+	podLogsCh := make(chan []string)
 	var logList []string
+	for _, pod := range podList {
 
-	if len(podList) > 0 {
-		for _, pod := range podList {
-
-			o.Podname = pod
-
-			err := fetchLogs(&logList, baseUrl, o)
-			if err != nil {
-				return err
-			}
-		}
-
-		err = printLogs(logList, streams, o.Limit)
+		go fetchLogs(baseUrl, o, pod, podLogsCh)
 		if err != nil {
-			return err
-		}
-
-	} else {
-
-		err = fetchLogs(&logList, baseUrl, o)
-		if err != nil {
-			return err
-		}
-
-		err = printLogs(logList, streams, o.Limit)
-
-		if err != nil {
-			return err
+			continue
 		}
 	}
+
+	for index := 0; index < len(podList); index++ {
+		podLogs := <-podLogsCh
+		logList = append(logList, podLogs...)
+	}
+
+	err = printLogs(logList, streams, o.Limit)
+	if err != nil {
+		return err
+	}
+
 	return nil
+
 }
 
-func fetchLogs(logList *[]string, baseUrl string, logParameters *LogParameters) error {
+func fetchLogs(baseUrl string, logParameters *LogParameters, podname string, podLogsCh chan<- []string) {
 
 	req, err := http.NewRequest("GET", baseUrl, nil)
+
 	if err != nil {
-		return fmt.Errorf("http request failed: %v", err)
+		fmt.Printf("unable to fetch logs of pod %s - http request failed: %v\n", podname, err)
+		podLogsCh <- nil
+		return
 	}
 
 	query := req.URL.Query()
-	query.Add("podname", logParameters.Podname)
+	query.Add("podname", podname)
 	query.Add("namespace", logParameters.Namespace)
 	query.Add("starttime", logParameters.StartTime)
 	query.Add("finishtime", logParameters.EndTime)
-	query.Add("maxlogs", logParameters.Limit)
+	query.Add("maxlogs", strconv.Itoa(logParameters.Limit))
 	query.Add("level", logParameters.Level)
 	req.URL.RawQuery = query.Encode()
 
 	response, err := http.DefaultClient.Do(req)
-
 	if err != nil {
-		return fmt.Errorf("failed to get http response %v", err)
+		fmt.Printf("unable to fetch logs of pod %s - failed to get http response %v\n", podname, err)
+		podLogsCh <- nil
+		return
 	}
 
 	responseBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return fmt.Errorf("failed to read response: %v", err)
+		fmt.Printf("unable to fetch logs of pod %s - failed to read response: %v\n", podname, err)
+		podLogsCh <- nil
+		return
 	}
 
 	err = response.Body.Close()
 
 	if err != nil {
-		return fmt.Errorf("an error occurred while attempting to close response body %v", err)
+		fmt.Printf("unable to fetch logs of pod %s - an error occurred while attempting to close response body %v\n", podname, err)
+		podLogsCh <- nil
+		return
 	}
 
 	jsonResponse := &ResponseLogs{}
 	err = json.Unmarshal(responseBody, &jsonResponse)
 	if err != nil {
-		return fmt.Errorf("an error occurred while unmarshalling JSON response: %v", err)
+		fmt.Printf("unable to fetch logs of pod %s - an error occurred while unmarshalling JSON response: %v\n", podname, err)
+		podLogsCh <- nil
+		return
 	}
 
+	var logList []string
 	for _, log := range jsonResponse.Logs {
 
 		logOption := logs.LogOptions{}
 		err := json.Unmarshal([]byte(log), &logOption)
 
 		if err != nil {
-			return fmt.Errorf("no logs present, or input parameters were invalid")
+			fmt.Printf("unable to fetch logs of pod %s - no logs present, or input parameters were invalid\n", podname)
+			podLogsCh <- nil
+			return
 		}
 
 		if len(logOption.Source.Message) > 0 {
 			if logParameters.Prefix && len(logOption.Source.Kubernetes.PodName) > 0 && len(logOption.Source.Kubernetes.ContainerName) > 0 {
-				*logList = append(*logList, "pod/"+logOption.Source.Kubernetes.PodName+"/"+logOption.Source.Kubernetes.ContainerName+"   "+logOption.Source.Message)
+				logList = append(logList, "pod/"+logOption.Source.Kubernetes.PodName+"/"+logOption.Source.Kubernetes.ContainerName+"   "+logOption.Source.Message)
 			} else {
-				*logList = append(*logList, logOption.Source.Message)
+				logList = append(logList, logOption.Source.Message)
 			}
 		}
 	}
-
-	return nil
+	podLogsCh <- logList
 }
 
-func printLogs(logList []string, streams genericclioptions.IOStreams, limit string) error {
+func printLogs(logList []string, streams genericclioptions.IOStreams, limit int) error {
 
 	if len(logList) == 0 {
 		return fmt.Errorf("no logs present, or input parameters were invalid")
 	}
 
-	var maxLogs int
 	var err error
-
-	if len(limit) > 0 {
-		maxLogs, err = strconv.Atoi(limit)
-		if err != nil || maxLogs < 0 || maxLogs > 1000 {
-			return fmt.Errorf("incorrect \"limit\" value entered, an integer value between 0 and 1000 is required")
-		}
-	}
 
 	for logCount, log := range logList {
 
-		if len(limit) > 0 && logCount >= maxLogs {
+		if logCount >= limit {
 			return nil
 		}
-		_, err := fmt.Fprintf(streams.Out, log+"\n")
+		_, err = fmt.Fprintf(streams.Out, log+"\n")
 		if err != nil {
 			return fmt.Errorf("an error occurred while printing logs: %v", err)
 		}
 	}
+
 	return nil
 }

--- a/pkg/cmd/historical_logs.go
+++ b/pkg/cmd/historical_logs.go
@@ -104,7 +104,7 @@ func (o *LogParameters) Execute(streams genericclioptions.IOStreams) error {
 		return err
 	}
 
-	err = o.ProcessLogParameters(kubernetesOptions)
+	err = o.ProcessLogParameters()
 
 	if err != nil {
 		return err

--- a/pkg/cmd/historical_logs.go
+++ b/pkg/cmd/historical_logs.go
@@ -1,25 +1,19 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/ViaQ/log-exploration-oc-plugin/pkg/client"
+	"github.com/ViaQ/log-exploration-oc-plugin/pkg/k8sresources"
+	"github.com/ViaQ/log-exploration-oc-plugin/pkg/logs"
 	"github.com/spf13/cobra"
 	"io/ioutil"
-	appsv1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 	"net/http"
-	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 )
 
 var (
@@ -47,30 +41,32 @@ var (
 		oc historical-logs --tail=5m
 		
 		# Return snapshot logs for pods in deployment log-exploration-api in the last 10 seconds
-		oc historical-logs --deployment=log-exploration-api --tail=10s`))
-)
+		oc historical-logs --deployment=log-exploration-api --tail=10s
 
-type LogParameters struct {
-	Namespace   string
-	Podname     string
-	Tail        string
-	StartTime   string
-	EndTime     string
-	Level       string
-	Limit       string
-	Deployment  string
-	StatefulSet string
-	DaemonSet   string
-	Prefix      bool
-}
+		# Return snapshot logs for pods in deployment log-exploration-api in namespace openshift-logging
+		oc historical-logs --deployment=log-exploration-api --namespace=openshift-logging`))
+)
 
 type ResponseLogs struct {
 	Logs []string
 }
 
+type LogParameters struct {
+	Namespace string
+	Podname   string
+	Tail      string
+	StartTime string
+	EndTime   string
+	Level     string
+	Limit     string
+	Prefix    bool
+	k8sresources.Resources
+}
+
 func NewCmdLogFilter(streams genericclioptions.IOStreams) *cobra.Command {
 
 	o := &LogParameters{}
+
 	cmd := &cobra.Command{
 		Use:     "historical-logs [flags]",
 		Short:   "View logs filtered on various parameters",
@@ -95,105 +91,50 @@ func (o *LogParameters) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.Tail, "tail", "", "Fetch Historical logs for the last N seconds, minutes, hours, or days")
 	cmd.Flags().StringVar(&o.Level, "level", "", "Fetch Historical logs from different logging level, Example: Info,debug,Error,Unknown, etc")
 	cmd.Flags().StringVar(&o.Limit, "limit", "", "Specify number of documents [logs] to be fetched. 1000 by default")
-	cmd.Flags().StringVar(&o.DaemonSet, "daemonset", "", "Fetch logs from pods of a Daemon Set")
-	cmd.Flags().StringVar(&o.StatefulSet, "statefulset", "", "Fetch logs from pods of a Stateful Set")
-	cmd.Flags().StringVar(&o.Deployment, "deployment", "", "Fetch logs from pods of a Deployment")
+	cmd.Flags().StringVar(&o.Resources.DaemonSet, "daemonset", "", "Fetch logs from pods of a Daemon Set")
+	cmd.Flags().StringVar(&o.Resources.StatefulSet, "statefulset", "", "Fetch logs from pods of a Stateful Set")
+	cmd.Flags().StringVar(&o.Resources.Deployment, "deployment", "", "Fetch logs from pods of a Deployment")
 	cmd.Flags().BoolVar(&o.Prefix, "prefix", false, "Prefix each log with the log source (pod name and container name)")
 }
 
 func (o *LogParameters) Execute(streams genericclioptions.IOStreams) error {
 
-	kubeconfig := filepath.Join(
-		os.Getenv("HOME"), ".kube", "config",
-	)
-
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	kubernetesOptions, err := client.KubernetesClient()
 	if err != nil {
-		return fmt.Errorf("kubeconfig Error: %v", err)
+		return err
 	}
 
-	clientset, err := kubernetes.NewForConfig(config)
+	err = o.ProcessLogParameters(kubernetesOptions)
+
 	if err != nil {
-		return fmt.Errorf("an error occurred while creating a kubernetes client: %v", err)
-	}
-
-	clusterUrl := config.Host
-	endIndex := strings.LastIndex(clusterUrl, ":")
-	startIndex := strings.Index(clusterUrl, ".") + 1
-	clusterName := clusterUrl[startIndex:endIndex]
-
-	/*Example cluster URL : http://api.sangupta-tetrh.devcluster.openshift.com:6443. The first occurrence of '.' and last occurrence of ':'
-	act as start and end indices. Extract cluster name as substring using start and end Indices i.e, sangupta-tetrh.devcluster.openshift.com to build the log-exploration-api URL*/
-
-	ApiUrl := "http://log-exploration-api-route-openshift-logging.apps." + clusterName + "/logs/filter"
-
-	if len(o.Tail) > 0 {
-		tail, err := strconv.Atoi(o.Tail[0 : len(o.Tail)-1]) //extract numeric value. For example, extract 50 from 50s or 10 from 10m
-		if err != nil {
-			return fmt.Errorf("an invalid \"tail\" value was entered: %v", err)
-		}
-
-		timeUnit := o.Tail[len(o.Tail)-1] //Last character (time unit) is 's'(seconds),'m'(minutes),'h'(hours),'d'(days)
-		endTime := time.Now().UTC()
-		var startTime time.Time
-
-		switch timeUnit {
-		case 's':
-			startTime = endTime.Add(time.Duration(-tail) * time.Second).UTC()
-		case 'm':
-			startTime = endTime.Add(time.Duration(-tail) * time.Minute).UTC()
-		case 'h':
-			startTime = endTime.Add(time.Duration(-tail) * time.Hour).UTC()
-		case 'd':
-			startTime = endTime.Add(time.Duration(-tail) * time.Hour * 24)
-		default:
-			return fmt.Errorf("invalid time unit entered in \"tail\". please enter s, m, h, or d as time unit")
-		}
-
-		o.StartTime = startTime.UTC().Format(time.RFC3339Nano)
-		o.EndTime = endTime.UTC().Format(time.RFC3339Nano)
+		return err
 	}
 
 	var podList []string
 
-	if len(o.Deployment) > 0 {
-		err = GetDeploymentPodsList(clientset, o.Deployment, o.Namespace, &podList)
-		if err != nil {
-			return err
-		}
+	podList, err = k8sresources.GetResourcesPodList(kubernetesOptions, &o.Resources, o.Namespace)
+
+	if err != nil {
+		return err
 	}
 
-	if len(o.DaemonSet) > 0 {
-		err = GetDaemonSetPodsList(clientset, o.DaemonSet, o.Namespace, &podList)
-		if err != nil {
-			return err
-		}
-	}
+	endIndex := strings.LastIndex(kubernetesOptions.ClusterUrl, ":")
+	startIndex := strings.Index(kubernetesOptions.ClusterUrl, ".") + 1
+	clusterName := kubernetesOptions.ClusterUrl[startIndex:endIndex]
 
-	if len(o.StatefulSet) > 0 {
-		err = GetStatefulSetPodsList(clientset, o.StatefulSet, o.Namespace, &podList)
-		if err != nil {
-			return err
-		}
-	}
+	/*Example cluster URL : http://api.sangupta-tetrh.devcluster.openshift.com:6443. The first occurrence of '.' and last occurrence of ':'
+	act as start and end indices. Extract cluster name as substring using start and end Indices i.e, sangupta-tetrh.devcluster.openshift.com to build the log-exploration-api URL*/
+
+	baseUrl := "http://log-exploration-api-route-openshift-logging.apps." + clusterName + "/logs/filter"
 
 	var logList []string
+
 	if len(podList) > 0 {
 		for _, pod := range podList {
 
 			o.Podname = pod
-			response, err := o.makeHttpRequest(ApiUrl)
 
-			if err != nil {
-				return err
-			}
-
-			responseBody, err := ioutil.ReadAll(response.Body)
-			if err != nil {
-				return fmt.Errorf("failed to read response: %v", err)
-			}
-
-			err = getLogs(responseBody, &logList, o.Prefix)
+			err := fetchLogs(&logList, baseUrl, o)
 			if err != nil {
 				return err
 			}
@@ -206,21 +147,13 @@ func (o *LogParameters) Execute(streams genericclioptions.IOStreams) error {
 
 	} else {
 
-		response, err := o.makeHttpRequest(ApiUrl)
-		if err != nil {
-			return err
-		}
-		responseBody, err := ioutil.ReadAll(response.Body)
-		if err != nil {
-			return fmt.Errorf("failed to read response: %v", err)
-		}
-
-		err = getLogs(responseBody, &logList, o.Prefix)
+		err = fetchLogs(&logList, baseUrl, o)
 		if err != nil {
 			return err
 		}
 
 		err = printLogs(logList, streams, o.Limit)
+
 		if err != nil {
 			return err
 		}
@@ -228,113 +161,56 @@ func (o *LogParameters) Execute(streams genericclioptions.IOStreams) error {
 	return nil
 }
 
-func (o *LogParameters) makeHttpRequest(baseUrl string) (*http.Response, error) {
+func fetchLogs(logList *[]string, baseUrl string, logParameters *LogParameters) error {
 
-	var urlBuilder strings.Builder
-	urlBuilder.WriteString(baseUrl)
-	numParameters := 0
-	if len(o.Podname) > 0 {
-		urlBuilder.WriteString("?")
-		urlBuilder.WriteString("podname=" + o.Podname)
-		numParameters = numParameters + 1
+	req, err := http.NewRequest("GET", baseUrl, nil)
+	if err != nil {
+		return fmt.Errorf("http request failed: %v", err)
 	}
-	if len(o.Namespace) > 0 {
-		if numParameters == 0 {
-			urlBuilder.WriteString("?")
-		} else {
-			urlBuilder.WriteString("&")
-		}
-		urlBuilder.WriteString("namespace=" + o.Namespace)
-		numParameters = numParameters + 1
-	}
-	if len(o.Limit) > 0 {
-		if numParameters == 0 {
-			urlBuilder.WriteString("?")
-		} else {
-			urlBuilder.WriteString("&")
-		}
-		urlBuilder.WriteString("maxlogs=" + o.Limit)
-		numParameters = numParameters + 1
-	}
-	if len(o.Level) > 0 {
-		if numParameters == 0 {
-			urlBuilder.WriteString("?")
-		} else {
-			urlBuilder.WriteString("&")
-		}
-		urlBuilder.WriteString("level=" + o.Level)
-		numParameters = numParameters + 1
-	}
-	if len(o.StartTime) > 0 && len(o.EndTime) > 0 {
-		if numParameters == 0 {
-			urlBuilder.WriteString("?")
-		} else {
-			urlBuilder.WriteString("&")
-		}
-		urlBuilder.WriteString("starttime=" + o.StartTime)
-		urlBuilder.WriteString("&finishtime=" + o.EndTime)
-		numParameters = numParameters + 1
-	}
-	response, err := http.Get(urlBuilder.String())
+
+	query := req.URL.Query()
+	query.Add("podname", logParameters.Podname)
+	query.Add("namespace", logParameters.Namespace)
+	query.Add("starttime", logParameters.StartTime)
+	query.Add("finishtime", logParameters.EndTime)
+	query.Add("maxlogs", logParameters.Limit)
+	query.Add("level", logParameters.Level)
+	req.URL.RawQuery = query.Encode()
+
+	response, err := http.DefaultClient.Do(req)
 
 	if err != nil {
-		return nil, fmt.Errorf("http request failed: %v", err)
-	}
-	return response, nil
-}
-
-func printLogs(logList []string, streams genericclioptions.IOStreams, limit string) error {
-
-	if len(logList) == 0 {
-		_, err := fmt.Fprintf(streams.Out, "No Logs Present, or logs from invalid resources were requested")
-		if err != nil {
-			return fmt.Errorf("an error occurred while printing logs: %v", err)
-		}
-		return nil
+		return fmt.Errorf("failed to get http response %v", err)
 	}
 
-	var maxLogs int
-	var err error
-
-	if len(limit) > 0 {
-		maxLogs, err = strconv.Atoi(limit)
-		if err != nil {
-			return fmt.Errorf("incorrect \"limit\" value entered")
-		}
+	responseBody, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %v", err)
 	}
 
-	for logCount, log := range logList {
+	err = response.Body.Close()
 
-		if len(limit) > 0 && logCount > maxLogs {
-			return nil
-		}
-		_, err := fmt.Fprintf(streams.Out, log+"\n")
-		if err != nil {
-			return fmt.Errorf("an error occurred while printing logs: %v", err)
-		}
+	if err != nil {
+		return fmt.Errorf("an error occurred while attempting to close response body %v", err)
 	}
-	return nil
-}
-
-func getLogs(responseBody []byte, logList *[]string, prefix bool) error {
 
 	jsonResponse := &ResponseLogs{}
-	err := json.Unmarshal(responseBody, &jsonResponse)
+	err = json.Unmarshal(responseBody, &jsonResponse)
 	if err != nil {
 		return fmt.Errorf("an error occurred while unmarshalling JSON response: %v", err)
 	}
 
 	for _, log := range jsonResponse.Logs {
 
-		logOption := LogOptions{}
+		logOption := logs.LogOptions{}
 		err := json.Unmarshal([]byte(log), &logOption)
 
 		if err != nil {
-			return nil //no logs present
+			return fmt.Errorf("no logs present, or input parameters were invalid")
 		}
 
 		if len(logOption.Source.Message) > 0 {
-			if prefix && len(logOption.Source.Kubernetes.PodName) > 0 && len(logOption.Source.Kubernetes.ContainerName) > 0 {
+			if logParameters.Prefix && len(logOption.Source.Kubernetes.PodName) > 0 && len(logOption.Source.Kubernetes.ContainerName) > 0 {
 				*logList = append(*logList, "pod/"+logOption.Source.Kubernetes.PodName+"/"+logOption.Source.Kubernetes.ContainerName+"   "+logOption.Source.Message)
 			} else {
 				*logList = append(*logList, logOption.Source.Message)
@@ -345,103 +221,31 @@ func getLogs(responseBody []byte, logList *[]string, prefix bool) error {
 	return nil
 }
 
-func GetDaemonSetPodsList(clientset *kubernetes.Clientset, targetDaemonSet string, namespace string, podList *[]string) error {
+func printLogs(logList []string, streams genericclioptions.IOStreams, limit string) error {
 
-	var requiredDaemonSet appsv1.DaemonSet
-	daemonsets, _ := clientset.AppsV1().DaemonSets(namespace).List(context.Background(), metav1.ListOptions{})
+	if len(logList) == 0 {
+		return fmt.Errorf("no logs present, or input parameters were invalid")
+	}
 
-	requiredDaemonSetFound := false
-	for _, daemonset := range daemonsets.Items {
-		if daemonset.ObjectMeta.Name == targetDaemonSet {
-			requiredDaemonSetFound = true
-			requiredDaemonSet = daemonset
-			break
+	var maxLogs int
+	var err error
+
+	if len(limit) > 0 {
+		maxLogs, err = strconv.Atoi(limit)
+		if err != nil || maxLogs < 0 || maxLogs > 1000 {
+			return fmt.Errorf("incorrect \"limit\" value entered, an integer value between 0 and 1000 is required")
 		}
 	}
 
-	if !requiredDaemonSetFound {
-		return fmt.Errorf("daemon set \"%v\" not found", targetDaemonSet)
-	}
-	labelSelector := labels.Set(requiredDaemonSet.Spec.Selector.MatchLabels)
+	for logCount, log := range logList {
 
-	options := metav1.ListOptions{
-		LabelSelector: string(labelSelector.AsSelector().String()),
-	}
-
-	pods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), options)
-
-	if err != nil {
-		return fmt.Errorf("an error occurred while fetching daemon set pods: %v", err)
-	}
-	for _, pod := range (*pods).Items {
-		*podList = append(*podList, pod.Name)
-	}
-	return nil
-}
-
-func GetStatefulSetPodsList(clientset *kubernetes.Clientset, targetStatefulSet string, namespace string, podList *[]string) error {
-
-	var requiredStatefulSet appsv1.StatefulSet
-	requiredStatefulSetFound := false
-	statefulSets, _ := clientset.AppsV1().StatefulSets(namespace).List(context.Background(), metav1.ListOptions{})
-
-	for _, statefulSet := range statefulSets.Items {
-		if statefulSet.ObjectMeta.Name == targetStatefulSet {
-			requiredStatefulSetFound = true
-			requiredStatefulSet = statefulSet
-			break
+		if len(limit) > 0 && logCount >= maxLogs {
+			return nil
 		}
-	}
-	if !requiredStatefulSetFound {
-		return fmt.Errorf("stateful set \"%v\" not found", targetStatefulSet)
-
-	}
-
-	labelSelector := labels.Set(requiredStatefulSet.Spec.Selector.MatchLabels)
-
-	options := metav1.ListOptions{
-		LabelSelector: string(labelSelector.AsSelector().String()),
-	}
-	pods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), options)
-	if err != nil {
-		return fmt.Errorf("an error occurred while fetching stateful set pods: %v", err)
-	}
-	for _, pod := range (*pods).Items {
-		*podList = append(*podList, pod.Name)
-	}
-	return nil
-
-}
-
-func GetDeploymentPodsList(clientset *kubernetes.Clientset, targetDeployment string, namespace string, podList *[]string) error {
-
-	var requiredDeployment appsv1.Deployment
-	deployments, _ := clientset.AppsV1().Deployments(namespace).List(context.Background(), metav1.ListOptions{})
-	requiredDeploymentFound := false
-
-	for _, deployment := range deployments.Items {
-		if deployment.ObjectMeta.Name == targetDeployment {
-			requiredDeploymentFound = true
-			requiredDeployment = deployment
-			break
+		_, err := fmt.Fprintf(streams.Out, log+"\n")
+		if err != nil {
+			return fmt.Errorf("an error occurred while printing logs: %v", err)
 		}
-	}
-
-	if !requiredDeploymentFound {
-		return fmt.Errorf("deployment \"%v\" not found", targetDeployment)
-	}
-
-	labelSelector := labels.Set(requiredDeployment.Spec.Selector.MatchLabels)
-
-	options := metav1.ListOptions{
-		LabelSelector: string(labelSelector.AsSelector().String()),
-	}
-	pods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), options)
-	if err != nil {
-		return fmt.Errorf("an error occurred while fetching deployment pods: %v", err)
-	}
-	for _, pod := range (*pods).Items {
-		*podList = append(*podList, pod.Name)
 	}
 	return nil
 }

--- a/pkg/cmd/historical_logs.go
+++ b/pkg/cmd/historical_logs.go
@@ -120,9 +120,6 @@ func (o *LogParameters) Execute(streams genericclioptions.IOStreams, args []stri
 	for _, pod := range podList {
 
 		go fetchLogs(baseUrl, o, pod, podLogsCh)
-		if err != nil {
-			continue
-		}
 	}
 
 	for index := 0; index < len(podList); index++ {

--- a/pkg/cmd/log_options.go
+++ b/pkg/cmd/log_options.go
@@ -3,9 +3,9 @@ package cmd
 import "time"
 
 type LogOptions struct {
-	ID     string `json:"_id"`
-	Index  string `json:"_index"`
-	Score  float64    `json:"_score"`
+	ID     string  `json:"_id"`
+	Index  string  `json:"_index"`
+	Score  float64 `json:"_score"`
 	Source struct {
 		Timestamp time.Time `json:"@timestamp"`
 		Docker    struct {

--- a/pkg/cmd/log_options.go
+++ b/pkg/cmd/log_options.go
@@ -5,7 +5,7 @@ import "time"
 type LogOptions struct {
 	ID     string `json:"_id"`
 	Index  string `json:"_index"`
-	Score  int    `json:"_score"`
+	Score  float64    `json:"_score"`
 	Source struct {
 		Timestamp time.Time `json:"@timestamp"`
 		Docker    struct {

--- a/pkg/cmd/process_params.go
+++ b/pkg/cmd/process_params.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/ViaQ/log-exploration-oc-plugin/pkg/client"
+	"strconv"
+	"time"
+)
+
+func (o *LogParameters) ProcessLogParameters(kubernetesOptions *client.KubernetesOptions) error {
+
+	if len(o.Tail) > 0 {
+		tail, err := strconv.Atoi(o.Tail[0 : len(o.Tail)-1]) //extract numeric value. For example, extract 50 from 50s or 10 from 10m
+		if err != nil {
+			return fmt.Errorf("an invalid \"tail\" value was entered: %v", err)
+		}
+
+		timeUnit := o.Tail[len(o.Tail)-1] //Last character (time unit) is 's'(seconds),'m'(minutes),'h'(hours),'d'(days)
+		endTime := time.Now().UTC()
+		var startTime time.Time
+
+		switch timeUnit {
+		case 's':
+			startTime = endTime.Add(time.Duration(-tail) * time.Second).UTC()
+		case 'm':
+			startTime = endTime.Add(time.Duration(-tail) * time.Minute).UTC()
+		case 'h':
+			startTime = endTime.Add(time.Duration(-tail) * time.Hour).UTC()
+		case 'd':
+			startTime = endTime.Add(time.Duration(-tail) * time.Hour * 24)
+		default:
+			return fmt.Errorf("invalid time unit entered in \"tail\". please enter s, m, h, or d as time unit")
+		}
+
+		o.StartTime = startTime.UTC().Format(time.RFC3339Nano)
+		o.EndTime = endTime.UTC().Format(time.RFC3339Nano)
+	}
+	return nil
+}

--- a/pkg/cmd/process_params.go
+++ b/pkg/cmd/process_params.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func (o *LogParameters) ProcessLogParameters(kubernetesOptions *client.KubernetesOptions) error {
+func (o *LogParameters) ProcessLogParameters() error {
 
 	if len(o.Tail) > 0 {
 		tail, err := strconv.Atoi(o.Tail[0 : len(o.Tail)-1]) //extract numeric value. For example, extract 50 from 50s or 10 from 10m

--- a/pkg/cmd/process_params.go
+++ b/pkg/cmd/process_params.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/ViaQ/log-exploration-oc-plugin/pkg/client"
 	"strconv"
 	"time"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,10 @@
+package constants
+
+const (
+	LimitLowerBound = 0
+	LimitUpperBound = 1000
+	Deployment      = "deployment"
+	DaemonSet       = "daemonset"
+	StatefulSet     = "statefulset"
+	Podname         = "podname"
+)

--- a/pkg/k8sresources/daemonset_pods.go
+++ b/pkg/k8sresources/daemonset_pods.go
@@ -1,0 +1,49 @@
+package k8sresources
+
+import (
+	"context"
+	"fmt"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+)
+
+func GetDaemonSetPodsList(clientset kubernetes.Interface, podList *[]string, targetDaemonset string, namespace string) error {
+
+	var requiredDaemonSet appsv1.DaemonSet
+	daemonsets, _ := clientset.AppsV1().DaemonSets(namespace).List(context.Background(), metav1.ListOptions{})
+
+	requiredDaemonSetFound := false
+	for _, daemonset := range daemonsets.Items {
+		if daemonset.ObjectMeta.Name == targetDaemonset {
+			requiredDaemonSetFound = true
+			requiredDaemonSet = daemonset
+			break
+		}
+	}
+
+	if !requiredDaemonSetFound {
+		if len(namespace) > 0 {
+			return fmt.Errorf("daemon set \"%v\" not found in namespace \"%v\"", targetDaemonset, namespace)
+		} else {
+			return fmt.Errorf("daemon set \"%v\" not found", targetDaemonset)
+		}
+	}
+
+	labelSelector := labels.Set(requiredDaemonSet.Spec.Selector.MatchLabels)
+
+	options := metav1.ListOptions{
+		LabelSelector: string(labelSelector.AsSelector().String()),
+	}
+
+	pods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), options)
+
+	if err != nil {
+		return fmt.Errorf("an error occurred while fetching daemon set pods: %v", err)
+	}
+	for _, pod := range (*pods).Items {
+		*podList = append(*podList, pod.Name)
+	}
+	return nil
+}

--- a/pkg/k8sresources/deployment_pods.go
+++ b/pkg/k8sresources/deployment_pods.go
@@ -1,0 +1,47 @@
+package k8sresources
+
+import (
+	"context"
+	"fmt"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+)
+
+func GetDeploymentPodsList(clientset kubernetes.Interface, podList *[]string, targetDeployment string, namespace string) error {
+
+	var requiredDeployment appsv1.Deployment
+	deployments, _ := clientset.AppsV1().Deployments(namespace).List(context.Background(), metav1.ListOptions{})
+	requiredDeploymentFound := false
+
+	for _, deployment := range deployments.Items {
+		if deployment.ObjectMeta.Name == targetDeployment {
+			requiredDeploymentFound = true
+			requiredDeployment = deployment
+			break
+		}
+	}
+
+	if !requiredDeploymentFound {
+		if len(namespace) > 0 {
+			return fmt.Errorf("deployment \"%v\" not found in namespace \"%v\"", targetDeployment, namespace)
+		} else {
+			return fmt.Errorf("deployment \"%v\" not found", targetDeployment)
+		}
+	}
+
+	labelSelector := labels.Set(requiredDeployment.Spec.Selector.MatchLabels)
+
+	options := metav1.ListOptions{
+		LabelSelector: string(labelSelector.AsSelector().String()),
+	}
+	pods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), options)
+	if err != nil {
+		return fmt.Errorf("an error occurred while fetching deployment pods: %v", err)
+	}
+	for _, pod := range (*pods).Items {
+		*podList = append(*podList, pod.Name)
+	}
+	return nil
+}

--- a/pkg/k8sresources/log_source.go
+++ b/pkg/k8sresources/log_source.go
@@ -8,25 +8,33 @@ func GetResourcesPodList(kubernetesOptions *client.KubernetesOptions, resources 
 
 	var podList []string
 
-	if len(resources.Deployment) > 0 {
-		err := GetDeploymentPodsList(kubernetesOptions.Clientset, &podList, resources.Deployment, namespace)
+	if resources.IsDeployment {
+		err := GetDeploymentPodsList(kubernetesOptions.Clientset, &podList, resources.Name, namespace)
 		if err != nil {
 			return nil, err
 		}
+		return podList, nil
 	}
 
-	if len(resources.DaemonSet) > 0 {
-		err := GetDaemonSetPodsList(kubernetesOptions.Clientset, &podList, resources.DaemonSet, namespace)
+	if resources.IsDaemonSet {
+		err := GetDaemonSetPodsList(kubernetesOptions.Clientset, &podList, resources.Name, namespace)
 		if err != nil {
 			return nil, err
 		}
+		return podList, nil
 	}
 
-	if len(resources.StatefulSet) > 0 {
-		err := GetStatefulSetPodsList(kubernetesOptions.Clientset, &podList, resources.StatefulSet, namespace)
+	if resources.IsStatefulSet {
+		err := GetStatefulSetPodsList(kubernetesOptions.Clientset, &podList, resources.Name, namespace)
 		if err != nil {
 			return nil, err
 		}
+		return podList, nil
 	}
-	return podList, nil
+
+	if resources.IsPod {
+		podList = append(podList, resources.Name)
+		return podList, nil
+	}
+	return nil, nil
 }

--- a/pkg/k8sresources/log_source.go
+++ b/pkg/k8sresources/log_source.go
@@ -1,0 +1,32 @@
+package k8sresources
+
+import (
+	"github.com/ViaQ/log-exploration-oc-plugin/pkg/client"
+)
+
+func GetResourcesPodList(kubernetesOptions *client.KubernetesOptions, resources *Resources, namespace string) ([]string, error) {
+
+	var podList []string
+
+	if len(resources.Deployment) > 0 {
+		err := GetDeploymentPodsList(kubernetesOptions.Clientset, &podList, resources.Deployment, namespace)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if len(resources.DaemonSet) > 0 {
+		err := GetDaemonSetPodsList(kubernetesOptions.Clientset, &podList, resources.DaemonSet, namespace)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if len(resources.StatefulSet) > 0 {
+		err := GetStatefulSetPodsList(kubernetesOptions.Clientset, &podList, resources.StatefulSet, namespace)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return podList, nil
+}

--- a/pkg/k8sresources/resources.go
+++ b/pkg/k8sresources/resources.go
@@ -1,7 +1,9 @@
 package k8sresources
 
 type Resources struct {
-	Deployment  string
-	DaemonSet   string
-	StatefulSet string
+	IsDeployment  bool
+	IsDaemonSet   bool
+	IsStatefulSet bool
+	IsPod         bool
+	Name          string
 }

--- a/pkg/k8sresources/resources.go
+++ b/pkg/k8sresources/resources.go
@@ -1,0 +1,7 @@
+package k8sresources
+
+type Resources struct {
+	Deployment  string
+	DaemonSet   string
+	StatefulSet string
+}

--- a/pkg/k8sresources/statefulset_pods.go
+++ b/pkg/k8sresources/statefulset_pods.go
@@ -1,0 +1,47 @@
+package k8sresources
+
+import (
+	"context"
+	"fmt"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+)
+
+func GetStatefulSetPodsList(clientset kubernetes.Interface, podList *[]string, targetStatefulSet string, namespace string) error {
+
+	var requiredStatefulSet appsv1.StatefulSet
+	requiredStatefulSetFound := false
+	statefulSets, _ := clientset.AppsV1().StatefulSets(namespace).List(context.Background(), metav1.ListOptions{})
+
+	for _, statefulSet := range statefulSets.Items {
+		if statefulSet.ObjectMeta.Name == targetStatefulSet {
+			requiredStatefulSetFound = true
+			requiredStatefulSet = statefulSet
+			break
+		}
+	}
+
+	if !requiredStatefulSetFound {
+		if len(namespace) > 0 {
+			return fmt.Errorf("stateful set \"%v\" not found in namespace \"%v\"", targetStatefulSet, namespace)
+		} else {
+			return fmt.Errorf("stateful set \"%v\" not found", targetStatefulSet)
+		}
+	}
+
+	labelSelector := labels.Set(requiredStatefulSet.Spec.Selector.MatchLabels)
+
+	options := metav1.ListOptions{
+		LabelSelector: string(labelSelector.AsSelector().String()),
+	}
+	pods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), options)
+	if err != nil {
+		return fmt.Errorf("an error occurred while fetching stateful set pods: %v", err)
+	}
+	for _, pod := range (*pods).Items {
+		*podList = append(*podList, pod.Name)
+	}
+	return nil
+}

--- a/pkg/logs/log_options.go
+++ b/pkg/logs/log_options.go
@@ -1,4 +1,4 @@
-package cmd
+package logs
 
 import "time"
 


### PR DESCRIPTION
refactored oc-plugin to accept and print logs of `daemon sets`, `deployments`, and `stateful set` pods, and switched to http `GET` request with url query parameters.